### PR TITLE
FEAT: Update AudioTrack functionality on mobile/tablet

### DIFF
--- a/src/components/ui/AudioTrack/AudioTrack.module.css
+++ b/src/components/ui/AudioTrack/AudioTrack.module.css
@@ -66,7 +66,6 @@
   width: 100%;
   height: 100%;
   display: flex;
-  justify-content: flex-start;
   align-items: center;
   padding-left: 16px;
 }

--- a/src/components/ui/AudioTrack/AudioTrack.module.css
+++ b/src/components/ui/AudioTrack/AudioTrack.module.css
@@ -72,8 +72,8 @@
 
 @media screen and (min-width: 1280px) {
   .playToggle {
-    display: none;
     padding-left: 0;
+    opacity: 0;
   }
 }
 
@@ -90,17 +90,18 @@
 
 /* Desktop hover effects */
 @media screen and (min-width: 1280px) {
-  .root:hover {
+  .root:hover, .root:focus-within {
     width: calc(100% - 38px);
     left: 38px;
     color: rgb(var(--rgb-background));
     background-color: rgb(var(--rgb-accent));
   }
 
-  .root:hover .number {
+  .root:hover .number, .root:focus-within .number {
     display: none;
   }
-  .root:hover .playToggle {
-    display: flex;
+  .root:hover .playToggle, .root:focus-within .playToggle {
+    opacity: 1;
+    outline: none;
   }
 }

--- a/src/components/ui/AudioTrack/AudioTrack.module.css
+++ b/src/components/ui/AudioTrack/AudioTrack.module.css
@@ -55,18 +55,26 @@
 }
 
 .playToggle {
-  display: flex;
-  justify-content: center;
-  align-items: center;
   background: transparent;
   border: 0;
   color: inherit;
   cursor: pointer;
+
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  padding-left: 16px;
 }
 
 @media screen and (min-width: 1280px) {
   .playToggle {
     display: none;
+    padding-left: 0;
   }
 }
 

--- a/src/components/ui/AudioTrack/AudioTrack.module.css
+++ b/src/components/ui/AudioTrack/AudioTrack.module.css
@@ -57,9 +57,9 @@
 .playToggle {
   background: transparent;
   border: 0;
+  outline: 0;
   color: inherit;
   cursor: pointer;
-
   position: absolute;
   top: 0;
   left: 0;
@@ -90,18 +90,21 @@
 
 /* Desktop hover effects */
 @media screen and (min-width: 1280px) {
-  .root:hover, .root:focus-within {
+  .root:hover,
+  .root:has(.playToggle:focus-visible) {
     width: calc(100% - 38px);
     left: 38px;
     color: rgb(var(--rgb-background));
     background-color: rgb(var(--rgb-accent));
   }
 
-  .root:hover .number, .root:focus-within .number {
+  .root:hover .number,
+  .root:has(.playToggle:focus-visible) .number {
     display: none;
   }
-  .root:hover .playToggle, .root:focus-within .playToggle {
+
+  .root:hover .playToggle,
+  .root:has(.playToggle:focus-visible) .playToggle {
     opacity: 1;
-    outline: none;
   }
 }

--- a/src/components/ui/AudioTrack/AudioTrack.tsx
+++ b/src/components/ui/AudioTrack/AudioTrack.tsx
@@ -37,6 +37,7 @@ export const AudioTrack = ({
           <button
             className={styles.playToggle}
             onClick={() => onPlayPauseClick(name)}
+            aria-label={isPlaying ? `Pause ${name} preview` : `Play ${name} preview` }
           >
             {isPlaying ? <FaPause /> : <FaPlay />}
           </button>


### PR DESCRIPTION
## Description

Button in `AudioTrack` component turn ON/OFF music when you press entire area of component at mobile and tablets.
Functionality of component at desktop has not been changed.

## Changes Made

- Added additional  styles for `playToggle` element in `AudioTrack.module.css` to make entire area clickable for tablets and mobile devices
- Provided `playToggle` element with `aria-label` to improve accessibility
- Ensured `playToggle` element is accessible with a keyboard