### PR TITLE
BUGFIX: Prevent the default behavior of ESC key exiting full-screen on modal

### DIFF
--- a/src/components/ui/Modal/hooks/useModal.ts
+++ b/src/components/ui/Modal/hooks/useModal.ts
@@ -20,8 +20,10 @@ export const useModal = () => {
 
   const closeByEsc = useCallback(
     (e: Event) => {
-      e.preventDefault()
-      if (e instanceof KeyboardEvent && e.code === 'Escape') closeModal()
+      if (e instanceof KeyboardEvent && e.code === 'Escape') {
+        e.preventDefault()
+        closeModal()
+      }
     },
     [closeModal]
   )

--- a/src/components/ui/Modal/hooks/useModal.ts
+++ b/src/components/ui/Modal/hooks/useModal.ts
@@ -20,6 +20,7 @@ export const useModal = () => {
 
   const closeByEsc = useCallback(
     (e: Event) => {
+      e.preventDefault()
       if (e instanceof KeyboardEvent && e.code === 'Escape') closeModal()
     },
     [closeModal]


### PR DESCRIPTION
## Description
Added `e.preventDefault()` to the `closeByEsc` callback to prevent Safari and Firefox from exiting full-screen mode when using ESC key to close the modal.

## Task Link
This pull request resolves #11 