### PR TITLE
BUGFIX: Fix Jittering on Hover near Audio Track left boundary

### DIFF
--- a/src/components/ui/AudioTrack/AudioTrack.module.css
+++ b/src/components/ui/AudioTrack/AudioTrack.module.css
@@ -1,4 +1,7 @@
 .root {
+  /* Local Variables */
+  --shift-distance: 38px;
+
   position: relative;
   left: 0;
   display: grid;
@@ -28,8 +31,8 @@
   }
 
   .root.isPlaying {
-    width: calc(100% - 38px);
-    left: 38px;
+    width: calc(100% - var(--shift-distance));
+    left: var(--shift-distance);
   }
 }
 
@@ -96,8 +99,8 @@
 
   .root:hover,
   .root:has(.playToggle:focus-visible) {
-    width: calc(100% - 38px);
-    left: 38px;
+    width: calc(100% - var(--shift-distance));
+    left: var(--shift-distance);
     color: rgb(var(--rgb-background));
     background-color: rgb(var(--rgb-accent));
   }
@@ -105,10 +108,10 @@
   .root:hover::after {
     position: absolute;
     content: '';
-    width: calc(100% + 38px);
+    width: calc(100% + var(--shift-distance));
     height: 100%;
     top: 0;
-    left: -38px;
+    left: calc(-1 * var(--shift-distance));
     z-index: -1;
   }
 

--- a/src/components/ui/AudioTrack/AudioTrack.module.css
+++ b/src/components/ui/AudioTrack/AudioTrack.module.css
@@ -90,12 +90,26 @@
 
 /* Desktop hover effects */
 @media screen and (min-width: 1280px) {
+  .root:hover {
+    z-index: 1;
+  }
+
   .root:hover,
   .root:has(.playToggle:focus-visible) {
     width: calc(100% - 38px);
     left: 38px;
     color: rgb(var(--rgb-background));
     background-color: rgb(var(--rgb-accent));
+  }
+
+  .root:hover::after {
+    position: absolute;
+    content: '';
+    width: calc(100% + 38px);
+    height: 100%;
+    top: 0;
+    left: -38px;
+    z-index: -1;
   }
 
   .root:hover .number,


### PR DESCRIPTION
## Description
"_CSS Jitter_", also known as "_Doom flicker_", can occur whenever you change the size of an object on hover including altering margins, padding, border size, or line-height.

The trouble occurs when the mouse is near the element's boundary. The hover effect takes the element out from under the mouse, which causes it to fall back down under the mouse, which causes the hover effect to trigger again. If you want to avoid CSS Jitter, refrain from styling the hover states of objects to change their size in any way.

If we still want to have such an animation, there are few techniques on [Fixing the Jitter Bug](https://codepen.io/csilverman/post/fixing-the-jitter-bug). I chose to use a pseudo-element to avoid extra markup.

## Task Link
This pull request resolves #18 

## Changes Made
- Used a pseudo-element to manage hover effects and avoid jittering.
- Replaced `38px` with the local CSS variable `--shift-distance` to improve code maintainability and flexibility.

## Screenshots, GIFs, or videos
While proposed solution addresses the jittering problem, there's a minor inconsistency: hovering over the extra space on the left side of the element may not produce the expected bounce-back effect. To any prevent confusion, a different design might be needed.

https://github.com/user-attachments/assets/c69a793f-9824-49e3-9403-1d20f10c2592

