### PR TITLE
REFACTOR: Refine Sections Content Width

### DIFF
--- a/src/app/components/AlbumItem/AlbumItem.module.css
+++ b/src/app/components/AlbumItem/AlbumItem.module.css
@@ -67,7 +67,7 @@
 }
 
 .detailsWrapper {
-  padding: 0 20px;
+  padding: 0 var(--page-side-padding);
 }
 
 @media screen and (min-width: 480px) {
@@ -108,7 +108,7 @@
 
 .buttons {
   grid-area: buttons;
-  padding: 0 20px;
+  padding: 0 var(--page-side-padding);
 }
 
 @media screen and (min-width: 480px) {

--- a/src/app/components/Gallery/Gallery.module.css
+++ b/src/app/components/Gallery/Gallery.module.css
@@ -3,15 +3,9 @@
   --desktop-gap: var(--image-gallery-desktop-gap);
 
   width: 100%;
-  max-width: calc(100% - 16px * 2);
+  max-width: calc(100% - (var(--page-side-padding) * 2));
   margin: 0 auto;
   padding-top: 100px;
-}
-
-@media screen and (min-width: 768px) {
-  .root {
-    max-width: calc(100% - 24px * 2);
-  }
 }
 
 @media screen and (min-width: 1024px) {
@@ -22,7 +16,7 @@
 
 @media screen and (min-width: 1272px) {
   .root {
-    max-width: 1184px;
+    max-width: var(--max-content-width);
   }
 }
 

--- a/src/app/components/Merch/Merch.module.css
+++ b/src/app/components/Merch/Merch.module.css
@@ -1,6 +1,6 @@
 .root {
-  width: calc(100% - 24px * 2);
-  max-width: var(--max-content-width);
+  width: 100%;
+  max-width: calc(100% - (var(--page-side-padding) * 2));
   margin: 0 auto;
   padding-top: 100px;
 }
@@ -13,14 +13,13 @@
 
 @media screen and (min-width: 1024px) {
   .root {
-    width: calc(100% - 48px * 2);
     padding: 120px 0 100px;
   }
 }
 
-@media screen and (min-width: 1280px) {
+@media screen and (min-width: 1272px) {
   .root {
-    width: 100%;
+    max-width: var(--max-content-width);
   }
 }
 

--- a/src/app/components/Music/Music.module.css
+++ b/src/app/components/Music/Music.module.css
@@ -1,12 +1,11 @@
 .root {
   width: 100%;
-  max-width: var(--max-content-width);
   padding-top: 100px;
 }
 
 @media screen and (min-width: 480px) {
   .root {
-    width: calc(100% - 24px * 2);
+    max-width: calc(100% - (var(--page-side-padding) * 2));
     margin: 0 auto;
     padding: 120px 0;
   }
@@ -14,14 +13,13 @@
 
 @media screen and (min-width: 1024px) {
   .root {
-    width: calc(100% - 48px * 2);
     padding: 120px 0 50px;
   }
 }
 
-@media screen and (min-width: 1280px) {
+@media screen and (min-width: 1272px) {
   .root {
-    width: 100%;
+    max-width: var(--max-content-width);
   }
 }
 

--- a/src/app/components/Press/Press.module.css
+++ b/src/app/components/Press/Press.module.css
@@ -1,6 +1,6 @@
 .root {
-  width: calc(100% - 16px * 2);
-  max-width: var(--max-content-width);
+  width: 100%;
+  max-width: calc(100% - (var(--page-side-padding) * 2));
   margin: 0 auto;
   padding-top: 100px;
 }
@@ -11,14 +11,8 @@
   }
 }
 
-@media screen and (min-width: 768px) {
-  .root {
-    max-width: calc(100% - 24px * 2);
-  }
-}
-
 @media screen and (min-width: 1272px) {
   .root {
-    max-width: 1184px;
+    max-width: var(--max-content-width);
   }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,4 @@
 :root {
-  --min-content-width: 414px;
   --max-content-width: 1170px;
   --page-side-padding: 16px;
   --border-radius: 4px;
@@ -48,7 +47,6 @@ body {
 
 main {
   flex-grow: 1;
-  min-width: var(--min-content-width);
 }
 
 a {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,5 @@
 :root {
-  --max-content-width: 1170px;
+  --max-content-width: 1184px;
   --page-side-padding: 16px;
   --border-radius: 4px;
   --rgb-foreground: 248, 247, 240;

--- a/src/components/Footer/Footer.module.css
+++ b/src/components/Footer/Footer.module.css
@@ -41,7 +41,7 @@
 
 @media screen and (min-width: 1272px) {
   .root {
-    max-width: 1184px;
+    max-width: var(--max-content-width);
     margin: 0 auto;
   }
 }

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -2,16 +2,10 @@
   position: fixed;
   top: 0;
   width: 100%;
-  padding: 0 48px;
+  padding: 0 var(--page-side-padding);
   flex-grow: 0;
   flex-shrink: 0;
   z-index: 3;
-}
-
-@media screen and (min-width: 1280px) {
-  .root {
-    padding: 0 50px;
-  }
 }
 
 @media screen and (min-width: 2560px) {

--- a/src/components/OverlayMenu/OverlayMenu.module.css
+++ b/src/components/OverlayMenu/OverlayMenu.module.css
@@ -5,7 +5,7 @@
   left: 0;
   overflow: auto;
   width: 100%;
-  height: 100vh;
+  height: 100dvh;
   background-color: rgb(var(--rgb-background));
   opacity: 0;
   transition: var(--common-transition);
@@ -24,3 +24,5 @@
   right: 30px;
   z-index: 3;
 }
+
+.nav { height: 100%; }

--- a/src/components/OverlayMenu/OverlayMenu.module.css
+++ b/src/components/OverlayMenu/OverlayMenu.module.css
@@ -21,7 +21,7 @@
 .toggle {
   position: fixed;
   top: 40px;
-  right: 30px;
+  right: var(--page-side-padding);
   z-index: 3;
 }
 

--- a/src/components/OverlayMenu/OverlayMenu.tsx
+++ b/src/components/OverlayMenu/OverlayMenu.tsx
@@ -17,7 +17,7 @@ export const OverlayMenu = () => {
     <>
       {/* prettier-ignore */}
       <div className={`${styles.root} ${isOverlayMenuOpen ? `${styles.isOpen}` : ''}`}>
-        <nav>
+        <nav className={styles.nav}>
           <Menu type='overlay-navigation'>
             {mainNavigationItems.map(({ id, text, href }) => (
               <Menu.Item

--- a/src/components/ui/List/type/events.module.css
+++ b/src/components/ui/List/type/events.module.css
@@ -1,29 +1,17 @@
 .root {
-  width: calc(100% - 20px * 2);
+  width: 100%;
+  max-width: calc(100% - (var(--page-side-padding) * 2));
   margin: 100px auto 0;
   list-style: none;
   border-top: 1px solid rgb(var(--rgb-inactive), 0.25);
   border-bottom: 1px solid rgb(var(--rgb-inactive), 0.25);
 }
+@media screen and (min-width: 1272px) {
+  .root {
+    max-width: unset;
+  }
+}
 
 .item:not(:last-child) {
   border-bottom: 1px solid rgb(var(--rgb-inactive), 0.25);
-}
-
-@media screen and (min-width: 480px) {
-  .root {
-    width: calc(100% - 24px * 2);
-  }
-}
-
-@media screen and (min-width: 1024px) {
-  .root {
-    width: calc(100% - 48px * 2);
-  }
-}
-
-@media screen and (min-width: 1280px) {
-  .root {
-    width: 100%;
-  }
 }

--- a/src/components/ui/List/type/merch.module.css
+++ b/src/components/ui/List/type/merch.module.css
@@ -1,7 +1,6 @@
 .root {
   display: grid;
   justify-content: center;
-  grid-template-columns: 360px;
   gap: 100px 14px;
   list-style: none;
 }

--- a/src/components/ui/List/type/track.module.css
+++ b/src/components/ui/List/type/track.module.css
@@ -3,7 +3,7 @@
   display: flex;
   flex-direction: column;
   gap: 1px;
-  padding: 0 20px;
+  padding: 0 var(--page-side-padding);
   list-style: none;
 }
 

--- a/src/components/ui/Menu/type/overlayNavigation.module.css
+++ b/src/components/ui/Menu/type/overlayNavigation.module.css
@@ -1,5 +1,5 @@
 .menu {
-  height: 100vh;
+  height: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
## Description
This PR addresses minor layout inconsistencies related to the width of page sections and removes the minimum width restriction, which was causing bugs on smaller mobile devices.

## Task Link
[Project Figma](https://www.figma.com/design/YKZFEj97V6fe8LADQR5lcq/ONE-FALL?node-id=0-1&t=Gr51OfE2P1Uth1KZ-0)

## Changes Made
- Removed the minimum width restriction and ensured the overlay menu takes the entire available view height.
- Updated the` --max-content-width` CSS variable to 1184px.
- Utilized the `--page-side-padding` and `--max-content-width` CSS variables for page sections to ensure a consistent look and enhance maintainability.

## Screenshots, GIFs, or videos
The video below illustrates how the minimum width restriction was causing horizontal scrolling on mobile devices with screens less than 414px wide:

https://github.com/user-attachments/assets/6adebd5d-3bee-4451-bfbf-6e8184f8a388

## Usage
By setting up the `--max-content-width` and `--page-side-padding` CSS variables in `globals.css`, we can now simplify most section setups and make them easier to maintain for future design changes.

```CSS
/* globals.css */
:root {
  --max-content-width: 1184px;
  --page-side-padding: 16px;
  ...
}

@media screen and (min-width: 768px) {
  :root {
    --page-side-padding: 24px;
  }
}

@media screen and (min-width: 1272px) {
  :root {
    --page-side-padding: 48px;
  }
}
```

This simplified setup will ensure the correct section width across all devices.
```CSS
.root {
  width: 100%;
  max-width: calc(100% - (var(--page-side-padding) * 2));
  margin: 0 auto;
}

@media screen and (min-width: 1272px) {
  .root {
    max-width: var(--max-content-width);
  }
}
```