### PR TITLE
BUGFIX: Ensure Hover Effects in Microsoft Edge

### DIFF
--- a/src/app/components/AlbumItem/AlbumItem.module.css
+++ b/src/app/components/AlbumItem/AlbumItem.module.css
@@ -41,7 +41,7 @@
   }
 }
 
-@media screen and (min-width: 1280px) {
+@media screen and (min-width: 1272px) {
   .root {
     grid-template-columns: 360px 1fr;
     gap: 40px 35px;

--- a/src/app/components/Events/data.json
+++ b/src/app/components/Events/data.json
@@ -1,19 +1,19 @@
 {
   "items": [
     {
-      "date": "2024-04-26T20:00:00.199Z",
+      "date": "2025-04-26T20:00:00.199Z",
       "city": "Lowell, MA",
       "venue": "The Town and City Festival",
       "url": "https://www.thetownandthecityfestival.com/"
     },
     {
-      "date": "2024-04-27T20:00:00.199Z",
+      "date": "2025-04-27T20:00:00.199Z",
       "city": "Queens, NY",
       "venue": "Bar Freda",
       "url": "https://www.barfreda.com/events"
     },
     {
-      "date": "2024-03-08T20:00:00.199Z",
+      "date": "2025-03-08T20:00:00.199Z",
       "city": "Medford, MA",
       "venue": "Deep Cuts",
       "url": "https://www.deepcuts.rocks/events"
@@ -31,7 +31,7 @@
       "url": "https://www.deepcuts.rocks/events"
     },
     {
-      "date": "2024-06-28T20:00:00.199Z",
+      "date": "2025-06-28T20:00:00.199Z",
       "city": "Oxford, UK",
       "venue": "The Library"
     },

--- a/src/components/ui/ArrowLink/ArrowLink.module.css
+++ b/src/components/ui/ArrowLink/ArrowLink.module.css
@@ -33,7 +33,7 @@
 }
 
 /* Desktop hover effects */
-@media screen and (min-width: 1280px) {
+@media screen and (min-width: 1272px) {
   .root:hover .text,
   .root:focus-within .text {
     color: rgb(var(--rgb-accent));

--- a/src/components/ui/AudioTrack/AudioTrack.module.css
+++ b/src/components/ui/AudioTrack/AudioTrack.module.css
@@ -24,7 +24,7 @@
   background-color: rgb(var(--rgb-accent));
 }
 
-@media screen and (min-width: 1280px) {
+@media screen and (min-width: 1272px) {
   .root {
     grid-template-columns: 16px 8fr 1fr;
     padding: 17px 70px 17px 37px;
@@ -44,7 +44,7 @@
   width: 100%;
 }
 
-@media screen and (min-width: 1280px) {
+@media screen and (min-width: 1272px) {
   .innerWrapper {
     position: relative;
     display: inline-block;
@@ -73,7 +73,7 @@
   padding-left: 16px;
 }
 
-@media screen and (min-width: 1280px) {
+@media screen and (min-width: 1272px) {
   .playToggle {
     padding-left: 0;
     opacity: 0;
@@ -92,7 +92,7 @@
 }
 
 /* Desktop hover effects */
-@media screen and (min-width: 1280px) {
+@media screen and (min-width: 1272px) {
   .root:hover {
     z-index: 1;
   }

--- a/src/components/ui/Button/Button.module.css
+++ b/src/components/ui/Button/Button.module.css
@@ -49,7 +49,7 @@
 }
 
 /* Desktop hover effects */
-@media screen and (min-width: 1280px) {
+@media screen and (min-width: 1272px) {
   .primary:not(:disabled):hover {
     color: rgb(var(--rgb-background));
     background-color: rgb(var(--rgb-accent));

--- a/src/components/ui/EventLink/EventLink.module.css
+++ b/src/components/ui/EventLink/EventLink.module.css
@@ -90,14 +90,14 @@
 
 /* Desktop hover effects */
 @media screen and (min-width: 1272px) {
-  .root:not(.isPast):hover,
-  .root:not(.isPast):focus-visible {
+  .root[href]:not(.isPast):hover,
+  .root[href]:not(.isPast):focus-visible {
     color: rgb(var(--rgb-background));
     background-color: rgb(var(--rgb-accent));
   }
 
-  .root:not(.isPast):hover .date,
-  .root:not(.isPast):focus-visible .date {
+  .root[href]:not(.isPast):hover .date,
+  .root[href]:not(.isPast):focus-visible .date {
     color: rgb(var(--rgb-background));
   }
 }

--- a/src/components/ui/EventLink/EventLink.module.css
+++ b/src/components/ui/EventLink/EventLink.module.css
@@ -13,6 +13,7 @@
   letter-spacing: 5px;
   vertical-align: text-bottom;
   background-color: transparent;
+  outline: none;
   transition: all 0.7s ease;
 }
 
@@ -34,7 +35,7 @@
   }
 }
 
-@media screen and (min-width: 1280px) {
+@media screen and (min-width: 1272px) {
   .root {
     grid-template-areas: 'date city venue';
     grid-template-columns: 260px 340px 1fr;
@@ -88,13 +89,15 @@
 }
 
 /* Desktop hover effects */
-@media screen and (min-width: 1280px) {
-  .root:not(.isPast):hover {
+@media screen and (min-width: 1272px) {
+  .root:not(.isPast):hover,
+  .root:not(.isPast):focus-visible {
     color: rgb(var(--rgb-background));
     background-color: rgb(var(--rgb-accent));
   }
 
-  .root:not(.isPast):hover .date {
+  .root:not(.isPast):hover .date,
+  .root:not(.isPast):focus-visible .date {
     color: rgb(var(--rgb-background));
   }
 }

--- a/src/components/ui/EventLink/EventLink.tsx
+++ b/src/components/ui/EventLink/EventLink.tsx
@@ -24,7 +24,13 @@ export const EventLink = ({ url, date, city, venue }: IEvent) => {
   }
 
   return (
-    <a className={classes} href={url} rel='noopener noreferrer' target='_blank'>
+    <a
+      className={classes}
+      href={url}
+      tabIndex={isPast ? -1 : 0}
+      rel='noopener noreferrer'
+      target='_blank'
+    >
       <FormattedDate
         dateString={date}
         outputFormat='month dd'

--- a/src/components/ui/IconButton/IconButton.module.css
+++ b/src/components/ui/IconButton/IconButton.module.css
@@ -13,7 +13,7 @@
   transition: var(--common-transition);
 }
 
-@media screen and (min-width: 1280px) {
+@media screen and (min-width: 1272px) {
   .root {
     width: 40px;
     height: 40px;

--- a/src/components/ui/List/type/merch.module.css
+++ b/src/components/ui/List/type/merch.module.css
@@ -11,7 +11,7 @@
   }
 }
 
-@media screen and (min-width: 1280px) {
+@media screen and (min-width: 1272px) {
   .root {
     gap: 100px 30px;
   }

--- a/src/components/ui/Menu/Item/MenuItem.tsx
+++ b/src/components/ui/Menu/Item/MenuItem.tsx
@@ -47,7 +47,13 @@ export const MenuItem = ({
       {iconGlyph ? (
         iconLinkElement
       ) : (
-        <Link className={classes} href={href} onClick={onClick} {...restProps}>
+        <Link
+          className={classes}
+          href={href}
+          tabIndex={current ? -1 : 0}
+          onClick={onClick}
+          {...restProps}
+        >
           {text}
         </Link>
       )}

--- a/src/components/ui/Menu/type/footerNavigation.module.css
+++ b/src/components/ui/Menu/type/footerNavigation.module.css
@@ -13,13 +13,10 @@
   transition: var(--common-transition);
 }
 
-.link:focus-visible {
-  color: rgb(var(--rgb-foreground));
-}
-
 /* Desktop hover effects */
 @media screen and (min-width: 1272px) {
-  .link:hover {
+  .link:hover,
+  .link:focus-visible  {
     color: rgb(var(--rgb-foreground));
   }
 

--- a/src/components/ui/Menu/type/footerSocialLinks.module.css
+++ b/src/components/ui/Menu/type/footerSocialLinks.module.css
@@ -19,11 +19,6 @@
   transition: var(--common-transition);
 }
 
-.link:focus-visible {
-  color: rgb(var(--rgb-foreground));
-  border: 1px solid rgb(var(--rgb-foreground));
-}
-
 @media screen and (min-width: 1272px) {
   .link {
     width: 40px;
@@ -32,7 +27,8 @@
   }
 
   /* Desktop hover effects */
-  .link:hover {
+  .link:hover,
+  .link:focus-visible {
     color: rgb(var(--rgb-foreground));
     border: 1px solid rgb(var(--rgb-foreground));
   }

--- a/src/components/ui/Menu/type/mainNavigation.module.css
+++ b/src/components/ui/Menu/type/mainNavigation.module.css
@@ -15,10 +15,12 @@
   letter-spacing: 0.015em;
   text-transform: uppercase;
   text-shadow: 0.15vw 0.15vw 0.15vw rgba(var(--rgb-foreground), 0.4);
+  outline: none;
   transition: var(--common-transition);
 }
 
-.link:hover {
+.link:hover,
+.link:focus-visible {
   color: rgb(var(--rgb-inactive));
   text-shadow: 0.15vw 0.15vw 0.15vw rgba(var(--rgb-inactive), 0.4);
 }
@@ -34,6 +36,7 @@
 }
 
 .link.covert:hover,
+.link.covert:focus-visible,
 .link.current {
   top: 0;
   color: rgb(var(--rgb-foreground));

--- a/src/components/ui/Menu/type/sidebarSocialLinks.module.css
+++ b/src/components/ui/Menu/type/sidebarSocialLinks.module.css
@@ -20,9 +20,11 @@
   color: rgb(var(--rgb-foreground));
   width: 40px;
   height: 40px;
+  outline: none;
 }
 
-.link:hover {
+.link:hover,
+.link:focus-visible  {
   background-color: rgb(var(--rgb-accent));
   color: rgb(var(--rgb-background));
 }


### PR DESCRIPTION
## Description

Unlike other browsers, Microsoft Edge's has a window border that reduces the viewport width by about 8px. This caused our hover effects, which were set to apply at a screen width of 1280px, to not work correctly in Edge.

## Task Link

This pull request resolves #6 

## Changes Made

- Changed the CSS media queries from `1280px` to `1272px` to fix the issue in Edge.
- Made sure keyboard navigation doesn't include current navigation links and past events.
- Removed hover / focus effects from event links that don't lead to actual external pages.
- Updated events mock data to include upcoming events for thorough testing.