### PR TITLE
BUGFIX: Ensure Sidebar Bandcamp Icon is Visible

### DIFF
--- a/public/images/icons/bandcamp-logo.svg
+++ b/public/images/icons/bandcamp-logo.svg
@@ -1,10 +1,3 @@
-<svg viewBox="0 0 22 23" xmlns="http://www.w3.org/2000/svg">
-  <g clip-path="url(#clip0_5786_3331)">
-    <path d="M0 18.0201L6.81725 5.64508H22L15.1818 18.0201H0Z" />
-  </g>
-  <defs>
-    <clipPath id="clip0_5786_3331">
-      <rect width="22" height="22" transform="translate(0 0.832581)" />
-    </clipPath>
-  </defs>
+<svg viewBox="0 0 26 15" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+  <path d="M0.868652 14.5312L8.61553 0.46875H25.8687L18.1207 14.5312H0.868652Z" />
 </svg>


### PR DESCRIPTION
## Description

This pull request addresses an issue where the Bandcamp icon was not consistently visible after screen rotations on iPad devices when using Safari. The same problem also occurred when resizing the browser window on the desktop. The current fix ensures the icon remains visible across all devices, browsers, and screen orientations.

## Task Link

This pull request resolves #33 

## Changes Made

- Replaced SVG icon for Bandcamp.
- Ensured the `fill='currentColor'` attribute is correctly applied to the SVG for consistent styling.

## Screenshots, GIFs, or videos

While I don't have access to an iPad device, I was able to reproduce the bug on desktop. Screen recordings below demonstrate the issue before and after the fix on the Safari browser:

https://github.com/user-attachments/assets/18a94875-d76e-4e2e-9ce1-7b3eccd481ea

https://github.com/user-attachments/assets/9ec9c756-a1f2-4d56-bbd8-e598dbdae513
