### PR TITLE
BUGFIX: Prevent Hover Effects on Main Navigation Links and Sidebar Social Links on Touch Devices

### DIFF
--- a/src/components/ui/Menu/type/mainNavigation.module.css
+++ b/src/components/ui/Menu/type/mainNavigation.module.css
@@ -19,7 +19,6 @@
   transition: var(--common-transition);
 }
 
-.link:hover,
 .link:focus-visible {
   color: rgb(var(--rgb-foreground-secondary));
   text-shadow: 0.15vw 0.15vw 0.15vw rgba(var(--rgb-foreground-secondary), 0.4);
@@ -35,7 +34,6 @@
   text-shadow: 0.15vw 0.15vw 0.15vw rgba(var(--rgb-foreground-secondary), 0.4);
 }
 
-.link.covert:hover,
 .link.covert:focus-visible,
 .link.current {
   top: 0;
@@ -45,4 +43,18 @@
 
 .link.current {
   pointer-events: none;
+}
+
+/* Apply styles if user has an input device capable of hovering (e.g., mouse, touchpad, or stylus) */
+@media (any-hover: hover) {
+  .link:hover {
+    color: rgb(var(--rgb-foreground-secondary));
+    text-shadow: 0.15vw 0.15vw 0.15vw rgba(var(--rgb-foreground-secondary), 0.4);
+  }
+
+  .link.covert:hover {
+    top: 0;
+    color: rgb(var(--rgb-foreground));
+    text-shadow: 0.15vw 0.15vw 0.15vw rgba(var(--rgb-foreground), 0.4);
+  }
 }

--- a/src/components/ui/Menu/type/sidebarSocialLinks.module.css
+++ b/src/components/ui/Menu/type/sidebarSocialLinks.module.css
@@ -23,7 +23,6 @@
   outline: none;
 }
 
-.link:hover,
 .link:focus-visible  {
   background-color: rgb(var(--rgb-accent));
   color: rgb(var(--rgb-background));
@@ -31,4 +30,12 @@
 
 .link:active {
   opacity: 0.7;
+}
+
+/* Apply styles if user has an input device capable of hovering(e.g., mouse, touchpad, or stylus) */
+@media (any-hover: hover) {
+  .link:hover {
+    background-color: rgb(var(--rgb-accent));
+    color: rgb(var(--rgb-background));
+  }
 }


### PR DESCRIPTION
## Description

This pull request fixes an issue where hover effects were mistakenly applied to main navigation and sidebar social links after closing a modal on touch devices. The problem occurred because touch interactions may sometimes activate hover styles, causing elements beneath to appear hovered even though they were not directly interacted with.

To fix this, `@media (any-hover: hover)` is used to apply hover styles only on devices that support true hover interactions, like a mouse or touchpad. This prevents the unintended hover effects on touch devices.

## Task Link

This pull request closes #35 

## Screenshots, GIFs, or videos

This fix also resolves the same issue when the modal is closed by tapping on the backdrop above the social links sidebar.

https://github.com/user-attachments/assets/a03aa2ce-3495-4528-99e0-c7e71ff435de

