### PR TITLE
BUGFIX: Remove Focus After Returning from External Page for Non-Keyboard Users

### DIFF
--- a/src/components/ui/ArrowLink/ArrowLink.module.css
+++ b/src/components/ui/ArrowLink/ArrowLink.module.css
@@ -35,18 +35,18 @@
 /* Desktop hover effects */
 @media screen and (min-width: 1272px) {
   .root:hover .text,
-  .root:focus-within .text {
+  .root:focus-visible .text {
     color: rgb(var(--rgb-accent));
   }
 
   .root:hover .arrow:first-of-type,
-  .root:focus-within .arrow:first-of-type {
+  .root:focus-visible .arrow:first-of-type {
     transform: translateX(0);
     color: rgb(var(--rgb-accent));
   }
 
   .root:hover .arrow,
-  .root:focus-within .arrow:nth-child(2) {
+  .root:focus-visible .arrow:nth-child(2) {
     transform: translateX(45px);
   }
 }

--- a/src/components/ui/Button/Button.module.css
+++ b/src/components/ui/Button/Button.module.css
@@ -36,16 +36,14 @@
   cursor: auto;
 }
 
-@media screen and (min-width: 480px) {
-  .primary:focus {
-    color: rgb(var(--rgb-background));
-    background-color: rgb(var(--rgb-accent));
-  }
+.primary:focus-visible {
+  color: rgb(var(--rgb-background));
+  background-color: rgb(var(--rgb-accent));
+}
 
-  .secondary:focus {
-    color: rgb(var(--rgb-foreground));
-    border-color: rgb(var(--rgb-foreground));
-  }
+ .secondary:focus-visible {
+  color: rgb(var(--rgb-foreground));
+  border-color: rgb(var(--rgb-foreground));
 }
 
 /* Desktop hover effects */


### PR DESCRIPTION
## Description

This PR removes focus styles after visiting external links for mouse and touchpad users, while preserving them for keyboard users.

## Task Link

This pull request closes #38 