### PR TITLE
BUGFIX: Reset border radius property for inputs in footer form

### DIFF
--- a/src/components/ui/TextInput/TextInput.module.css
+++ b/src/components/ui/TextInput/TextInput.module.css
@@ -7,6 +7,7 @@
   color: rgb(var(--rgb-foreground-secondary));
   background-color: transparent;
   border: 0;
+  border-radius: 0;
   border-bottom: 1px solid rgb(var(--rgb-foreground-secondary));
   outline: none;
   transition: var(--common-transition);


### PR DESCRIPTION
## Description

This PR simply adds `border-raduis: 0` for `TextField` component in footer form. In this case bottom border in those components displays as expected (without rounded corners on Apple devices).

## Task Link

This PR closes issue #39 

![photo_2024-08-15_22-25-14](https://github.com/user-attachments/assets/d7028228-5364-4993-823e-9ab24d7151e4)