### PR TITLE
BUGFIX: Disable Tap Highlight on Mobile Devices

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -30,6 +30,8 @@
   box-sizing: border-box;
   padding: 0;
   margin: 0;
+  -webkit-tap-highlight-color: transparent;
+  -moz-tap-highlight-color: transparent;
 }
 
 html {


### PR DESCRIPTION
## Description

This pull request disables the default tap highlight effect on mobile devices by setting `-webkit-tap-highlight-color` and `-moz-tap-highlight-color` to `transparent` for all elements on the webpage. This change ensures consistent styling across devices without the semitransparent blue backdrop appearing on touch interactions.

## Task Link

This pull request closes #27 