### PR TITLE
BUGFIX: Improve Playback UI Updates in Music Player

### DIFF
--- a/src/app/components/Music/Music.tsx
+++ b/src/app/components/Music/Music.tsx
@@ -17,8 +17,10 @@ export const Music = () => {
   const { items } = data
   const audioTrackRefs = useInitAudioTrackRefs(items)
   const {
+    prevTrackName,
     currentTrackName,
     currentTrackTimeProgress,
+    playbackPaused,
     handlePlayPauseClick,
   } = useMusicPlayer(audioTrackRefs)
 
@@ -42,6 +44,7 @@ export const Music = () => {
                 {...track}
                 timeProgress={currentTrackTimeProgress}
                 isPlaying={currentTrackName === track.name}
+                isPaused={prevTrackName === track.name && playbackPaused}
                 onPlayPauseClick={handlePlayPauseClick}
                 tabIndex={tabIndex}
               />

--- a/src/app/components/Music/hooks/useInitAudioTrackRefs.ts
+++ b/src/app/components/Music/hooks/useInitAudioTrackRefs.ts
@@ -1,27 +1,23 @@
-import { createRef, useEffect, useState } from 'react'
+import { createRef, useMemo } from 'react'
 import { IAlbum, ITrack, TAudioRef } from '@/helpers/types'
 
 export const useInitAudioTrackRefs = (items: IAlbum[]) => {
-  const [tracks, setTracks] = useState<ITrack[]>([])
-  const audioTrackRefs: Record<string, TAudioRef> = {}
+  const audioTrackRefs = useMemo(() => {
+    const refs: Record<string, TAudioRef> = {}
 
-  useEffect(() => {
-    const getAllTracks = (items: IAlbum[]) => {
-      let allTracks: ITrack[] = []
+    const allTracks: ITrack[] = []
+    items.forEach(album => {
+      album.tracks.items.forEach((track: ITrack) => allTracks.push(track))
+    })
 
-      items.forEach(album => {
-        album.tracks.items.forEach((track: ITrack) => allTracks.push(track))
-      })
+    allTracks.forEach(track => {
+      if (!refs[track.name]) {
+        refs[track.name] = createRef<HTMLAudioElement>()
+      }
+    })
 
-      setTracks(allTracks)
-    }
-
-    getAllTracks(items)
+    return refs
   }, [items])
-
-  tracks.forEach(
-    track => (audioTrackRefs[track.name] = createRef<HTMLAudioElement>())
-  )
 
   return audioTrackRefs
 }

--- a/src/app/components/Music/hooks/useMusicPlayer.ts
+++ b/src/app/components/Music/hooks/useMusicPlayer.ts
@@ -5,6 +5,7 @@ type TMusicPlayerState = {
   prevTrackName: string
   currentTrackName: string
   isPlaying: boolean
+  playbackPaused: boolean
   currentTrackTimeProgress: number
 }
 
@@ -27,6 +28,7 @@ const initialState: TMusicPlayerState = {
   prevTrackName: '',
   currentTrackName: '',
   isPlaying: false,
+  playbackPaused: false,
   currentTrackTimeProgress: 0,
 }
 
@@ -36,12 +38,14 @@ const reducer = (state: TMusicPlayerState, action: MusicPlayerAction) => {
       return {
         ...state,
         isPlaying: true,
+        playbackPaused: false,
         currentTrackName: action.payload.trackName,
       }
     case Pause:
       return {
         ...state,
         isPlaying: false,
+        playbackPaused: true,
         prevTrackName: state.currentTrackName,
         currentTrackName: '',
       }
@@ -63,7 +67,7 @@ const reducer = (state: TMusicPlayerState, action: MusicPlayerAction) => {
 
 export const useMusicPlayer = (audioTrackRefs: Record<string, TAudioRef>) => {
   const [
-    { prevTrackName, currentTrackName, isPlaying, currentTrackTimeProgress },
+    { prevTrackName, currentTrackName, isPlaying, playbackPaused, currentTrackTimeProgress },
     dispatch,
   ] = useReducer(reducer, initialState)
 
@@ -123,8 +127,10 @@ export const useMusicPlayer = (audioTrackRefs: Record<string, TAudioRef>) => {
   }
 
   return {
-    currentTrackName: currentTrackName,
-    currentTrackTimeProgress: currentTrackTimeProgress,
+    prevTrackName,
+    currentTrackName,
+    currentTrackTimeProgress,
+    playbackPaused,
     handlePlayPauseClick,
   }
 }

--- a/src/app/components/Music/hooks/useMusicPlayer.ts
+++ b/src/app/components/Music/hooks/useMusicPlayer.ts
@@ -83,7 +83,6 @@ export const useMusicPlayer = (audioTrackRefs: Record<string, TAudioRef>) => {
       }
     }
 
-    // TODO: Ensure only one timer
     if (isPlaying) {
       const intervalId = setInterval(updateProgress, 1000)
       return () => clearInterval(intervalId)

--- a/src/components/ui/AudioTrack/AudioTrack.module.css
+++ b/src/components/ui/AudioTrack/AudioTrack.module.css
@@ -20,7 +20,8 @@
   transition: all 0.7s ease;
 }
 
-.root.isPlaying {
+.root.isPlaying,
+.root.isPaused {
   color: rgb(var(--rgb-background));
   background-color: rgb(var(--rgb-accent));
 }
@@ -99,7 +100,8 @@
   }
 
   .root:hover,
-  .root:has(.playToggle:focus-visible) {
+  .root:has(.playToggle:focus-visible),
+  .root.isPaused {
     width: calc(100% - var(--shift-distance));
     left: var(--shift-distance);
     color: rgb(var(--rgb-background));
@@ -117,12 +119,14 @@
   }
 
   .root:hover .number,
-  .root:has(.playToggle:focus-visible) .number {
+  .root:has(.playToggle:focus-visible) .number,
+  .root.isPaused .number {
     display: none;
   }
 
   .root:hover .playToggle,
-  .root:has(.playToggle:focus-visible) .playToggle {
+  .root:has(.playToggle:focus-visible) .playToggle,
+  .root.isPaused .playToggle {
     opacity: 1;
   }
 }

--- a/src/components/ui/AudioTrack/AudioTrack.tsx
+++ b/src/components/ui/AudioTrack/AudioTrack.tsx
@@ -11,6 +11,7 @@ interface IAudioTrackProps {
   dataFileUrl: string
   timeProgress: number
   isPlaying: boolean
+  isPaused: boolean
   onPlayPauseClick: (name: string) => void
   tabIndex: number
 }
@@ -21,15 +22,18 @@ export const AudioTrack = ({
   timeProgress = 0,
   dataFileUrl,
   isPlaying,
+  isPaused,
   onPlayPauseClick,
   tabIndex,
 }: IAudioTrackProps) => {
   const audioTrackRefs = useAudioTrackRefs()
   const duration = useAudioTrackDuration(audioTrackRefs[name])
 
+  const classes = `${styles.root} ${isPlaying ? styles.isPlaying : ''} ${isPaused ? styles.isPaused : ''}`
+
   return (
     <>
-      <div className={`${styles.root} ${isPlaying ? styles.isPlaying : ''}`}>
+      <div className={classes}>
         <div className={styles.innerWrapper}>
           <span className={styles.number}>
             {isPlaying ? (
@@ -49,7 +53,7 @@ export const AudioTrack = ({
         </div>
         <span className={styles.name}>{name}</span>
         <FormattedDuration
-          durationInSeconds={isPlaying ? timeProgress : duration}
+          durationInSeconds={isPlaying || isPaused ? timeProgress : duration}
           outputFormat='colon-separated'
           className={styles.duration}
         />


### PR DESCRIPTION
## Description

This pull request enhances the `useMusicPlayer` hook to ensure accurate UI updates and improves performance by optimizing how audio track references are handled.

## Task Link

This pull request closes #41, #43 

## Changes Made

- Added `playbackPaused` state to the `useMusicPlayer` hook to ensure the UI correctly reflects playback status.
- Memoized `audioTrackRefs` to prevent unnecessary re-renders and avoid interval recreation in the `useMusicPlayer` hook.
- Added event listener to stop equalizer animation and update playback state when audio track ends.